### PR TITLE
Remove doc step from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run lint && mocha -r ts-node/register tests/**/*.spec.ts",
     "prettier": "balena-lint --typescript --fix lib typings examples tests",
     "lint": "balena-lint --typescript lib typings examples tests",
-    "build": "rimraf build doc && tsc && npm run doc",
+    "build": "rimraf build doc && tsc",
     "doc": "typedoc --readme none --theme markdown --mode file --out doc lib && sed -i 's|'$(pwd)'||g' $(find doc -type f)",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
Generating the documentation doesn't work on node 12, which is necessary for using pre-built binaries for lzma-native for windows. We don't need the documentation for anything and generating it prevents the package from being built on windows.